### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
   build-release:
     name: Release Build + MSI
     runs-on: windows-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/knausj85/Windows-Hinting/security/code-scanning/4](https://github.com/knausj85/Windows-Hinting/security/code-scanning/4)

In general, the fix is to explicitly declare a minimal `permissions` block for any job that currently relies on default `GITHUB_TOKEN` permissions, setting it to the least privileges needed (usually `contents: read` for pure build/test jobs).

For this workflow, we should add `permissions: contents: read` to the `build-release` job, mirroring the CodeQL suggestion and the intended usage of the job. This job only checks out code, restores packages, builds, signs, verifies, and uploads artifacts; none of these steps require write access to the repository or other GitHub resources. We’ll add the `permissions` block directly under `runs-on: windows-latest` for the `build-release` job (around lines 50–52), using the same indentation style as the existing `release` job, which already declares `permissions: contents: write`. No additional methods, imports, or definitions are needed since this is a pure YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
